### PR TITLE
schemas v0.0.2: additionalProperties set to false

### DIFF
--- a/schemas.md
+++ b/schemas.md
@@ -16,7 +16,7 @@ Property Template:
 - use resourceTemplates at outer level instead of valueConstraint.valueTemplateRefs (or move valueTemplateRefs out a level and get rid of )
 - move useValuesFrom out a level, instead of valueConstraints.useValuesFrom
 - move defaults out a level, instead of valueConstraints.defaults
-- move dataTypeURI out two levels, instead of valueConstraints.valueDataType.dataTypeURI or maybe include it within default, since it is only used for type lookup with a default.
+- move dataTypeURI out two levels, instead of valueConstraints.valueDataType.dataTypeURI or maybe include it within default, if it is only used for (type lookup with a ?) default.
 - conditional JSON schemas that only allow appropriate valueConstraints given the type:
     - lookup:  
            - require useValuesFrom and disallow valueTemplateRefs
@@ -71,6 +71,24 @@ The schemas are:
 
 special bonus schema
 - <https://ld4p.github.io/sinopia/schemas/0.1.0/profiles-array.json>
+
+
+## Version 0.0.2
+
+Version 0.0.2 JSON Schemas are the same as Version 0.0.1, but additionalProperties has been set to false for all properties of type "object".  This means the object (e.g. profile or resourceTemplate or propertyTemplate or valueConstraint ..) is not valid if it has additional properties that weren’t explicitly listed in the JSON schema.
+
+It was an oversight that this wasn't included in Version 0.0.1 schemas.
+
+Also:  resourceTemplate can have author attribute.
+
+- https://ld4p.github.io/sinopia/schemas/0.0.2/profile.json>
+- <https://ld4p.github.io/sinopia/schemas/0.0.2/resource-templates-array.json>
+- <https://ld4p.github.io/sinopia/schemas/0.0.2/resource-template.json>
+- <https://ld4p.github.io/sinopia/schemas/0.0.2/property-templates-array.json>
+- <https://ld4p.github.io/sinopia/schemas/0.0.2/property-template.json>
+
+special bonus schema
+- <https://ld4p.github.io/sinopia/schemas/0.0.2/profiles-array.json>
 
 
 ## Version 0.0.1

--- a/schemas/0.0.2/profile.json
+++ b/schemas/0.0.2/profile.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://ld4p.github.io/sinopia/schemas/0.0.2/profile.json",
+  "type": "object",
+  "title": "LC Profile Schema (by Sinopia)",
+  "description": "Profile, or array of Resource Templates with some top-level metadata.",
+  "version": "0.0.2",
+  "required": [ "Profile" ],
+  "additionalProperties": false,
+  "properties": {
+    "Profile": {
+      "type": "object",
+      "title": "Profile" ,
+      "description": "Profile key always at top level of a LC BFE / Sinopia BFF Profile.",
+      "required": [
+        "date",
+        "description",
+        "id",
+        "resourceTemplates",
+        "title"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "author": {
+          "type": "string",
+          "title": "Author",
+          "description": "Contact information associated with the profile.",
+          "example": [
+            "PCC",
+            "Michelle Futornick",
+            "Cornell University Cataloging Department"
+          ]
+        },
+        "date": {
+          "type": "string",
+          "format": "date",
+          "title": "Date",
+          "description": "Date associated with the profile",
+          "example": [
+            "2017-05-20"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Textual description associated with the profile.",
+          "example": [
+            "Metadata for BIBFRAME Resources"
+          ]
+        },
+        "id": {
+          "type": "string",
+          "title": "Identifier",
+          "description": "Unique identifier associated with the profile. Eventually, a Profile URI.",
+          "example": [
+            "profile:bf2:AdminMetadata",
+            "http://sinopia.io/resources/common/AdminMetadataProfile"
+          ]
+        },
+        "remark": {
+          "type": "string",
+          "title": "Remark",
+          "description": "Comment or guiding statement intended to be presented as supplementary information in user display."
+        },
+        "resourceTemplates": {
+          "$ref": "https://ld4p.github.io/sinopia/schemas/0.0.2/resource-templates-array.json"
+        },
+        "title": {
+          "type": "string",
+          "title": "Title",
+          "description": "Textual title associated with the profile.",
+          "example": [
+            "BIBFRAME 2.0 Admin Metadata"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/schemas/0.0.2/profiles-array.json
+++ b/schemas/0.0.2/profiles-array.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://ld4p.github.io/sinopia/schemas/0.0.2/profiles-array.json",
+  "title": "LC Profile Array Schema (i.e. Multiple Profiles) (by Sinopia)",
+  "version": "0.0.2",
+  "type": "array",
+  "items": {
+    "$ref": "https://ld4p.github.io/sinopia/schemas/0.0.2/profile.json"
+  }
+}

--- a/schemas/0.0.2/property-template.json
+++ b/schemas/0.0.2/property-template.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://ld4p.github.io/sinopia/schemas/0.0.2/property-template.json",
+  "title": "LC Property Template Schema (by Sinopia)",
+  "description": "Property template for property associated with the entity described by a resource template.",
+  "version": "0.0.2",
+  "type": "object",
+  "required": [
+    "propertyURI",
+    "propertyLabel",
+    "type"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "mandatory": {
+      "type": "string",
+      "title": "Mandatory",
+      "description": "Indication that the property is mandatory."
+    },
+    "propertyLabel": {
+      "type": "string",
+      "title": "Property Label",
+      "description": "Preferred, human readable label associated with the property.",
+      "example": [
+        "BIBFRAME 2.0 Admin Metadata"
+      ]
+    },
+    "propertyURI": {
+      "type": "string",
+      "format": "uri",
+      "title": "Property URI",
+      "description": "URI of the RDF property being described.",
+      "example": [
+        "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
+      ]
+    },
+    "remark": {
+      "type": "string",
+      "title": "Remark",
+      "description": "Comment or guiding statement intended to be presented as supplementary information in user display."
+    },
+    "repeatable": {
+      "type": "string",
+      "title": "Repeatable",
+      "description": "Indication that the property is repeatable."
+    },
+    "resourceTemplates": {
+      "type": "array",
+      "title": "Always empty array of Resource Template References",
+      "description": "This is not currently used",
+      "maxItems": 0
+    },
+    "type": {
+      "type": "string",
+      "enum": ["literal", "lookup", "resource", "target"],
+      "title": "Type",
+      "description": "Type of value (literal / resource / lookup / target) that is allowed by this property."
+    },
+    "valueConstraint": {
+      "type": "object",
+      "title": "Value Constraint",
+      "description": "Constraint associated with the value.",
+      "additionalProperties": false,
+      "properties": {
+        "valueLanguage": {
+          "type": "string",
+          "title": "literal value language",
+          "description": "Language specified for a literal.  Never used/ignored?",
+          "maxLength": 0
+        },
+        "remark": {
+          "type": "string",
+          "title": "dataType remark",
+          "description": "Comment or guiding statement intended to be presented as supplementary information in user display.  Ignored."
+        },
+        "editable": {
+          "type": "string",
+          "title": "Editable",
+          "description": "Whether the value provided for the property is meant to be modified by a cataloger."
+        },
+        "repeatable": {
+          "type": "string",
+          "title": "Repeatable",
+          "description": "Indication whether the valueConstraint(?) is repeatable. (confusing)"
+        },
+        "validatePattern": {
+          "type": "string",
+          "title": "validation pattern",
+          "description": "Regular expression for input validation.  Never used/ignored.",
+          "maxLength": 0
+        },
+        "valueTemplateRefs": {
+          "type": "array",
+          "title": "Array of Resource Template References",
+          "description": "Array of identifiers (eventually URIs) for Resource Templates.",
+          "items": {
+            "type": "string"
+          },
+          "example": [
+            "['profile:bf2:Agent:Person', 'profile:bf2:Identifiers:Barcode', 'profile:bflc:Agents:PrimaryContribution']"
+          ]
+        },
+        "useValuesFrom": {
+          "type": "array",
+          "title": "Use Values From (these URIs)",
+          "description": "Array of Authority URIs or Vocabulary Lookup API identifiers to perform a lookup against.",
+          "items": {
+            "type": "string"
+          },
+          "example": [
+            "['http://id.loc.gov/authorities/names', 'http://mlvlp04.loc.gov:8230/resources/works', 'http://id.loc.gov/authorities/genreForms']"
+          ]
+        },
+        "valueDataType": {
+          "type": "object",
+          "title": "Value Data Types",
+          "description": "Data Type information - Type URI and comments primarily.",
+          "required": [],
+          "additionalProperties": false,
+          "properties": {
+            "dataTypeURI": {
+              "type": "string",
+              "format": "uri",
+              "title": "Data Type URI",
+              "description": "URI for the Data Type of the Lookup Value in this value template.",
+              "example": [
+                "http://id.loc.gov/ontologies/bibframe/Work",
+                "http://id.loc.gov/ontologies/bflc/PrimaryContribution",
+                "http://www.loc.gov/mads/rdf/v1#Affiliation"
+              ]
+            },
+            "dataTypeLabel": {
+              "type": "string",
+              "title": "dataType Label",
+              "description": "Preferred, human readable label associated with the DataType.  Ignored."
+            },
+            "dataTypeLabelHint": {
+              "type": "string",
+              "title": "dataType LabelHint",
+              "description": "Short, human readable label for display purposes.  Ignored."
+            },
+            "remark": {
+              "type": "string",
+              "title": "dataType remark",
+              "description": "Comment or guiding statement intended to be presented as supplementary information in user display.  Ignored."
+            }
+          }
+        },
+        "defaults": {
+          "type": "array",
+          "title": "array of default values",
+          "description": "array of default values each comprised of default literal and URI",
+          "items": {
+            "type": "object",
+            "title": "default Literal + URI",
+            "description": "a default value is specified with a literal and a URI",
+            "required": ["defaultURI", "defaultLiteral"],
+            "additionalProperties": false,
+            "properties": {
+              "defaultURI": {
+                "type": "string",
+                "format": "uri",
+                "title": "Default URI",
+                "description": "default value URI"
+              },
+              "defaultLiteral": {
+                "type": "string",
+                "title": "Default Literal",
+                "description": "default literal value"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/0.0.2/property-templates-array.json
+++ b/schemas/0.0.2/property-templates-array.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://ld4p.github.io/sinopia/schemas/0.0.2/property-templates-array.json",
+  "title": "LC Property Template Array Schema (i.e. Multiple Property Templates) (by Sinopia)",
+  "version": "0.0.2",
+  "type": "array",
+  "items": {
+    "$ref": "https://ld4p.github.io/sinopia/schemas/0.0.2/property-template.json"
+  },
+  "minItems": 1
+}

--- a/schemas/0.0.2/resource-template.json
+++ b/schemas/0.0.2/resource-template.json
@@ -13,6 +13,16 @@
   ],
   "additionalProperties": false,
   "properties": {
+    "author": {
+      "type": "string",
+      "title": "Author",
+      "description": "Contact information associated with the profile.",
+      "example": [
+        "PCC",
+        "Michelle Futornick",
+        "Cornell University Cataloging Department"
+      ]
+    },
     "id": {
       "type": "string",
       "title": "Resource Template Identifier",

--- a/schemas/0.0.2/resource-template.json
+++ b/schemas/0.0.2/resource-template.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://ld4p.github.io/sinopia/schemas/0.0.2/resource-template.json",
+  "type": "object",
+  "title": "LC Resource Template Schema (by Sinopia)",
+  "version": "0.0.2",
+  "description": "A Resource Template construct (or hash) describes one of the various Sinopia entities (Works, Instances, Agent, etc.) associated with a given entity type and set of properties asserted against the entity.",
+  "required": [
+    "id",
+    "resourceURI",
+    "resourceLabel",
+    "propertyTemplates"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "title": "Resource Template Identifier",
+      "description": "Identifier associated with a resource template. Eventually, a URI.",
+      "example": [
+        "profile:bf2:AdminMetadata",
+        "http://sinopia.io/resources/common/AbstractResourceTemplate"
+      ]
+    },
+    "propertyTemplates": {
+      "$ref": "https://ld4p.github.io/sinopia/schemas/0.0.2/property-templates-array.json"
+    },
+    "remark": {
+      "type": "string",
+      "title": "Remark",
+      "description": "Comment or guiding statement intended to be presented as supplementary information in user display."
+    },
+    "resourceLabel": {
+      "type": "string",
+      "title": "Resource Label",
+      "description": "Preferred, human readable label associated with the resource template.",
+      "example": [
+        "BIBFRAME 2.0 Admin Metadata"
+      ]
+    },
+    "resourceURI": {
+      "type": "string",
+      "format": "uri",
+      "title": "Resource URI",
+      "description": "URI of the RDF resource type associated with the entity managed by this Resource Template.",
+      "example": [
+        "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
+      ]
+    }
+  }
+}

--- a/schemas/0.0.2/resource-templates-array.json
+++ b/schemas/0.0.2/resource-templates-array.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://ld4p.github.io/sinopia/schemas/0.0.2/resource-templates-array.json",
+  "title": "LC Resource Template Array Schema (i.e. Multiple Resource Templates) (by Sinopia)",
+  "version": "0.0.2",
+  "type": "array",
+  "items": {
+    "$ref": "https://ld4p.github.io/sinopia/schemas/0.0.2/resource-template.json"
+  },
+  "minItems": 1
+}


### PR DESCRIPTION
From the update to `schemas.md`:

Version 0.0.2 JSON Schemas are the same as Version 0.0.1, but additionalProperties has been set to false for all properties of type "object".  This means the object (e.g. profile or resourceTemplate or propertyTemplate or valueConstraint ..) is not valid if it has additional properties that weren’t explicitly listed in the JSON schema.

It was an oversight that this wasn't included in Version 0.0.1 schemas.  (Frankly, I didn't realize you had to explicitly indicate that you didn't want random attributes declared in the JSON!)

Also - resourceTemplates should allow author.