### PR TITLE
Schemas v0.1.0 - updates

### DIFF
--- a/schemas.md
+++ b/schemas.md
@@ -32,7 +32,7 @@ Property Template:
 
 Version 0.1.0 JSON Schemas are streamlined for Sinopia work.  
 
-Changes from version 0.0.1:
+Changes from version 0.0.2:
 
 - Profile:
     - require author attribute
@@ -41,7 +41,7 @@ Changes from version 0.0.1:
     - add source attribute
 
 - Resource Template:
-    - add required author attribute
+    - require author attribute
     - add required date attribute
     - add required description attribute
     - add required schema attributes

--- a/schemas.md
+++ b/schemas.md
@@ -50,8 +50,10 @@ Changes from version 0.0.2:
 
 - Property Template:
     - type attribute can only be 'literal', 'resource', or 'lookup'
+      - 'resource' and 'lookup' require valueConstraint
     - mandatory and repeatable properties can be proper booleans OR strings (e.g. true or 'true')
     - valueConstraint.editable attribute removed as it will always be true
+    - valueConstraint can have at most one of useValuesFrom, valueTemplateRefs
     - removed attributes that were never used or ignored in profile editor, BFE and RDF generated:
       - valueConstraint.remark
       - valueConstraint.repeatabe (duplicate of outer repeatable attribute)

--- a/schemas/0.1.0/property-template.json
+++ b/schemas/0.1.0/property-template.json
@@ -136,7 +136,33 @@
             }
           }
         }
+      },
+      "dependencies": {
+        "valueTemplateRefs": { "not": { "required": ["useValuesFrom"] } },
+        "useValuesFrom": { "not": { "required": ["valueTemplateRefs"] } }
       }
     }
-  }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "type": { "const": "lookup" }
+        }
+      },
+      "then": {
+        "required": ["valueConstraint"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": { "const": "resource" }
+        }
+      },
+      "then": {
+        "required": ["valueConstraint"]
+      }
+    }
+  ]
 }


### PR DESCRIPTION
- adds a small part of the conditional logic based on property template type
- update schemas.md 

I would still like to get further with the conditional logic, in particular:

- conditional JSON schemas that only allow appropriate valueConstraints given the type:
    - lookup:  
           - require useValuesFrom and disallow valueTemplateRefs
    - resource:
       - require valueTemplateRefs/resourceTemplates and disallow useValuesFrom and possibly defaults
    - literal:
       - disallow valueTemplateRefs/resourceTemplates as well as useValuesFrom

But ... these changes are correct and can be merged as is.