### PR TITLE
Schemas v0.1.0:  conditional logic for valueConstraints given type of property

### DIFF
--- a/schemas.md
+++ b/schemas.md
@@ -13,19 +13,14 @@ Resource Template:
 - is there a real difference between description and resourceLabel?  If not, can we remove one?
 
 Property Template:
-- use resourceTemplates at outer level instead of valueConstraint.valueTemplateRefs (or move valueTemplateRefs out a level and get rid of )
+- defaults:
+    - is dataTypeURI associated with default values only? if so, adjust schema accordingly (put with defaults)
+    - is dataTypeURI required when defaults are specified? if so, adjust schema accordingly
+    - can a property with type resource have a default? if not, adjust schema accordingly
+- use resourceTemplates at outer level instead of valueConstraint.valueTemplateRefs (or move  valueTemplateRefs out a level and get rid of resourceTemplates)
 - move useValuesFrom out a level, instead of valueConstraints.useValuesFrom
 - move defaults out a level, instead of valueConstraints.defaults
 - move dataTypeURI out two levels, instead of valueConstraints.valueDataType.dataTypeURI or maybe include it within default, if it is only used for (type lookup with a ?) default.
-- conditional JSON schemas that only allow appropriate valueConstraints given the type:
-    - lookup:  
-           - require useValuesFrom and disallow valueTemplateRefs
-       - require dataTypeURI only when there is a default specified?
-    - resource:
-       - require valueTemplateRefs/resourceTemplates and disallow useValuesFrom and possibly defaults
-    - literal:
-       - disallow valueTemplateRefs/resourceTemplates as well as useValuesFrom
-       - require dataTypeURI only when there is a default specified?
 - only accept boolean (not string) for true/false.  (e.g. true not "true")
 
 ## Version 0.1.0
@@ -51,9 +46,21 @@ Changes from version 0.0.2:
 - Property Template:
     - type attribute can only be 'literal', 'resource', or 'lookup'
       - 'resource' and 'lookup' require valueConstraint
+    - conditional JSON schemas that only allow appropriate valueConstraints given the type:
+      - lookup:
+        - require useValuesFrom and disallow valueTemplateRefs
+        - (also disallow resourceTemplates)
+      - resource:
+        - require valueTemplateRefs and disallow useValuesFrom
+      - literal:
+        - disallow valueTemplateRefs as well as useValuesFrom
+        - (also disallow resourceTemplates)
     - mandatory and repeatable properties can be proper booleans OR strings (e.g. true or 'true')
-    - valueConstraint.editable attribute removed as it will always be true
     - valueConstraint can have at most one of useValuesFrom, valueTemplateRefs
+    - valueConstaint.useValuesFrom requires at least one entry (or it shouldn't be present)
+    - valueConstaint.valueTemplateRefs requires at least one entry (or it shouldn't be present)
+    - valueConstraint.valueDataType requires dataTypeURI (or it shouldn't be present)
+    - valueConstraint.editable attribute removed as it will always be true
     - removed attributes that were never used or ignored in profile editor, BFE and RDF generated:
       - valueConstraint.remark
       - valueConstraint.repeatabe (duplicate of outer repeatable attribute)

--- a/schemas/0.1.0/property-template.json
+++ b/schemas/0.1.0/property-template.json
@@ -99,6 +99,7 @@
           "title": "Value Data Types",
           "description": "Data Type information: Type URI.",
           "additionalProperties": false,
+          "required": ["dataTypeURI"],
           "properties": {
             "dataTypeURI": {
               "type": "string",

--- a/schemas/0.1.0/property-template.json
+++ b/schemas/0.1.0/property-template.json
@@ -79,7 +79,8 @@
           },
           "example": [
             "['profile:bf2:Agent:Person', 'profile:bf2:Identifiers:Barcode', 'profile:bflc:Agents:PrimaryContribution']"
-          ]
+          ],
+          "minItems": 1
         },
         "useValuesFrom": {
           "type": "array",

--- a/schemas/0.1.0/property-template.json
+++ b/schemas/0.1.0/property-template.json
@@ -140,6 +140,7 @@
           }
         }
       },
+      "$comment": "Use at most one of useValuesFrom, valueTemplateRefs",
       "dependencies": {
         "valueTemplateRefs": { "not": { "required": ["useValuesFrom"] } },
         "useValuesFrom": { "not": { "required": ["valueTemplateRefs"] } }
@@ -154,7 +155,11 @@
         }
       },
       "then": {
-        "required": ["valueConstraint"]
+        "$comment": "forbid resourceTemplates and require valueConstraint.useValuesFrom",
+        "allOf": [
+          { "not": { "required": ["resourceTemplates"] } },
+          { "$ref": "#/definitions/requires-valueConstraint-useValuesFrom" }
+        ]
       }
     },
     {
@@ -164,8 +169,48 @@
         }
       },
       "then": {
-        "required": ["valueConstraint"]
+        "$comment": "require valueConstraint.valueTemplateRefs",
+        "$ref": "#/definitions/requires-valueConstraint-valueTemplateRefs"
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": { "const": "literal" }
+        }
+      },
+      "then": {
+        "$comment": "forbid resourceTemplates, valueConstraint.useValuesFrom and valueConstraint.valueTemplateRefs",
+        "allOf": [
+          { "not": { "required": ["resourceTemplates"] } },
+          { "$ref": "#/definitions/valueConstraint-requires-neither-templateRefs-nor-valuesFrom" }
+        ]
       }
     }
-  ]
+  ],
+  "definitions": {
+    "requires-valueConstraint-useValuesFrom": {
+      "required": ["valueConstraint"],
+      "properties": {
+        "valueConstraint" : {
+          "required": ["useValuesFrom"]
+        }
+      }
+    },
+    "requires-valueConstraint-valueTemplateRefs": {
+      "required": ["valueConstraint"],
+      "properties": {
+        "valueConstraint" : {
+          "required": ["valueTemplateRefs"]
+        }
+      }
+    },
+    "valueConstraint-requires-neither-templateRefs-nor-valuesFrom": {
+      "properties": {
+        "valueConstraint" : {
+          "not": { "required": [ "useValuesFrom", "valueTemplateRefs"] }
+        }
+      }
+    }
+  }
 }

--- a/schemas/0.1.0/property-template.json
+++ b/schemas/0.1.0/property-template.json
@@ -91,7 +91,8 @@
           },
           "example": [
             "['http://id.loc.gov/authorities/names', 'http://mlvlp04.loc.gov:8230/resources/works', 'http://id.loc.gov/authorities/genreForms']"
-          ]
+          ],
+          "minItems": 1
         },
         "valueDataType": {
           "type": "object",


### PR DESCRIPTION
w00t!  I figured out how to express that a property of type "lookup" must have `valueConstraint.useValuesFrom` and must not have `resourceTemplates`, etc.

I also tightened up some small things:  require an element in valueConstraint array values (or don't provide the element!) and require the only element in valueConstraint.valueDataTypes.

There are additional resourceTemplate simplifications I would like to implement (see https://ld4p.github.io/sinopia/schemas), but I think this batch of changes will do a lot to prevent nonsense and pure noise from getting into the resourceTemplates.