### PR TITLE
property-template schema v0.1.0: conditional logic: add allOf to avoid error

### DIFF
--- a/schemas/0.1.0/property-template.json
+++ b/schemas/0.1.0/property-template.json
@@ -170,7 +170,9 @@
       },
       "then": {
         "$comment": "require valueConstraint.valueTemplateRefs",
-        "$ref": "#/definitions/requires-valueConstraint-valueTemplateRefs"
+        "allOf": [
+          { "$ref": "#/definitions/requires-valueConstraint-valueTemplateRefs" }
+        ]
       }
     },
     {

--- a/schemas/0.1.0/property-template.json
+++ b/schemas/0.1.0/property-template.json
@@ -210,7 +210,10 @@
     "valueConstraint-requires-neither-templateRefs-nor-valuesFrom": {
       "properties": {
         "valueConstraint" : {
-          "not": { "required": [ "useValuesFrom", "valueTemplateRefs"] }
+          "allOf": [
+            { "not": { "required": [ "useValuesFrom" ] } },
+            { "not": { "required": [ "valueTemplateRefs" ] } }
+          ]
         }
       }
     }


### PR DESCRIPTION
I just noticed the validation was giving an error

```
[ndushay@m3dl-sm-03-mbph-2 sinopia (schemas-v0.1.0-again)]$ ajv validate -s schemas/0.1.0/profile.json -r 'schemas/0.1.0/*.json' -d "../sinopia_sample_profiles/profiles/v0.1.0/*.json" --all-errors --verbose
$ref: keywords ignored in schema at path "#/allOf/1/then"
../sinopia_sample_profiles/profiles/v0.1.0/BIBFRAME 2.0 Admin Metadata.json valid
<snip>
../sinopia_sample_profiles/profiles/v0.1.0/PMO Medium of Performance.json valid
[ndushay@m3dl-sm-03-mbph-2 sinopia (schemas-v0.1.0-again)]$
```

And this tweak means we don't get `$ref: keywords ignored in schema at path "#/allOf/1/then"`