### PR TITLE
schemas/0.1.0: add minLength to strings to avoid empty strings; add missing examples

### DIFF
--- a/schemas/0.1.0/profile.json
+++ b/schemas/0.1.0/profile.json
@@ -27,6 +27,7 @@
           "type": "string",
           "title": "Adherence",
           "description": "The standards or rules that this profile adheres to.",
+          "minLength": 3,
           "example": [
             "PCC",
             "PCC RDA Working Group"
@@ -36,6 +37,7 @@
           "type": "string",
           "title": "Author",
           "description": "Contact information associated with the profile.",
+          "minLength": 2,
           "example": [
             "PCC",
             "Michelle Futornick",
@@ -47,6 +49,7 @@
           "format": "date",
           "title": "Date",
           "description": "Date associated with the profile",
+          "minLength": 4,
           "example": [
             "2017-05-20"
           ]
@@ -55,6 +58,7 @@
           "type": "string",
           "title": "Description",
           "description": "Textual description associated with the profile.",
+          "minLength": 3,
           "example": [
             "Metadata for BIBFRAME Resources"
           ]
@@ -63,6 +67,7 @@
           "type": "string",
           "title": "Identifier",
           "description": "Unique identifier associated with the profile. Eventually, a Profile URI.",
+          "minLength": 3,
           "example": [
             "profile:bf2:AdminMetadata",
             "http://sinopia.io/resources/common/AdminMetadataProfile"
@@ -71,7 +76,11 @@
         "remark": {
           "type": "string",
           "title": "Remark",
-          "description": "Comment or guiding statement intended to be presented as supplementary information in user display."
+          "description": "Comment or guiding statement intended to be presented as supplementary information in user display.",
+          "minLength": 3,
+          "example": [
+            "Title information relating to a resource: work title, preferred title, instance title, transcribed title, translated title, variant form of title, etc."
+          ]
         },
         "resourceTemplates": {
           "$ref": "https://ld4p.github.io/sinopia/schemas/0.1.0/resource-templates-array.json"
@@ -79,23 +88,29 @@
         "schema": {
           "const": "https://ld4p.github.io/sinopia/schemas/0.1.0/profile.json",
           "title": "URL for Profile's JSON schema",
-          "description": "The profile adheres to the JSON schema at this URL"
+          "description": "The profile adheres to the JSON schema at this URL",
+          "minLength": 8,
+          "example": [
+            "https://ld4p.github.io/sinopia/schemas/0.1.0/profile.json"
+          ]
         },
         "source": {
           "type": "string",
           "format": "uri",
           "title": "Source URI",
           "description": "URL or URI for the profile in the author's source repository or space.",
+          "minLength": 5,
           "example": [
-            "https://raw.githubusercontent.com/LD4P/sinopia_sample_profiles/master/verso/BIBFRAME%202.0%20Admin%20Metadata.json"
+            "https://raw.githubusercontent.com/LD4P/sinopia_sample_profiles/master/profiles/v0.1.0/BIBFRAME%202.0%20Agents.json"
           ]
         },
         "title": {
           "type": "string",
           "title": "Title",
           "description": "Textual title associated with the profile.",
+          "minLength": 3,
           "example": [
-            "BIBFRAME 2.0 Admin Metadata"
+            "BIBFRAME 2.0 Agents"
           ]
         }
       }

--- a/schemas/0.1.0/property-template.json
+++ b/schemas/0.1.0/property-template.json
@@ -13,7 +13,7 @@
   "additionalProperties": false,
   "properties": {
     "mandatory": {
-      "type": ["boolean","string"],
+      "type": ["boolean", "string"],
       "enum": ["true", "false"],
       "title": "Mandatory",
       "description": "Indication that a value for the property is required. If unspecified, defaults to false.",
@@ -23,6 +23,7 @@
       "type": "string",
       "title": "Property Label",
       "description": "Preferred, human readable label associated with the property.",
+      "minLength": 3,
       "example": [
         "Search LCNAF/LCSH",
         "Place of Origin of the Work (RDA 6.5)",
@@ -36,6 +37,7 @@
       "format": "uri",
       "title": "Property URI",
       "description": "URI of the RDF property to be used.",
+      "minLength": 8,
       "example": [
         "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
       ]
@@ -43,7 +45,13 @@
     "remark": {
       "type": "string",
       "title": "Remark",
-      "description": "Comment or guiding statement intended to be presented as supplementary information in user display."
+      "description": "Comment or guiding statement intended to be presented as supplementary information in user display.",
+      "minLength": 3,
+      "example": [
+        "http://access.rdatoolkit.org/6.17.html",
+        "http://www.loc.gov/mads/rdf/v1#",
+        "https://www.loc.gov/standards/mods/userguide/recordinfo.html#recordidentifier"
+      ]
     },
     "repeatable": {
       "type": ["boolean","string"],
@@ -77,10 +85,10 @@
           "items": {
             "type": "string"
           },
+          "minItems": 1,
           "example": [
-            "['profile:bf2:Agent:Person', 'profile:bf2:Identifiers:Barcode', 'profile:bflc:Agents:PrimaryContribution']"
-          ],
-          "minItems": 1
+            "['sinopia:resourceTemplate:bf2:Agent:Person', 'sinopia:resourceTemplate:bf2:Identifiers:Barcode', 'sinopia:resourceTemplate:bflc:Agents:PrimaryContribution']"
+          ]
         },
         "useValuesFrom": {
           "type": "array",
@@ -89,10 +97,10 @@
           "items": {
             "type": "string"
           },
+          "minItems": 1,
           "example": [
             "['http://id.loc.gov/authorities/names', 'http://mlvlp04.loc.gov:8230/resources/works', 'http://id.loc.gov/authorities/genreForms']"
-          ],
-          "minItems": 1
+          ]
         },
         "valueDataType": {
           "type": "object",
@@ -106,6 +114,7 @@
               "format": "uri",
               "title": "Data Type URI",
               "description": "URI for the Data Type of the Lookup Value default.",
+              "minLength": 5,
               "example": [
                 "http://id.loc.gov/ontologies/bibframe/Work",
                 "http://id.loc.gov/ontologies/bflc/PrimaryContribution",
@@ -129,12 +138,22 @@
                 "type": "string",
                 "format": "uri",
                 "title": "Default URI",
-                "description": "default value URI"
+                "description": "default value URI",
+                "minLength": 5,
+                "examples": [
+                  "http://id.loc.gov/vocabulary/contentTypes/prm",
+                  "http://id.loc.gov/vocabulary/subjectSchemes/lcsh"
+                ]
               },
               "defaultLiteral": {
                 "type": "string",
                 "title": "Default Literal",
-                "description": "default literal value"
+                "description": "default literal value",
+                "minLength": 1,
+                "examples": [
+                  "performed music",
+                  "LCSH"
+                ]
               }
             }
           }

--- a/schemas/0.1.0/resource-template.json
+++ b/schemas/0.1.0/resource-template.json
@@ -10,8 +10,8 @@
     "date",
     "id",
     "propertyTemplates",
-    "resourceURI",
     "resourceLabel",
+    "resourceURI",
     "schema"
   ],
   "additionalProperties": false,
@@ -20,6 +20,7 @@
       "type": "string",
       "title": "Adherence",
       "description": "The standards or rules that this resource template adheres to.",
+      "minLength": 3,
       "example": [
         "PCC",
         "PCC RDA Working Group"
@@ -29,6 +30,7 @@
       "type": "string",
       "title": "Author",
       "description": "Contact information associated with the resource template.",
+      "minLength": 2,
       "example": [
         "PCC",
         "Michelle Futornick",
@@ -40,6 +42,7 @@
       "format": "date",
       "title": "Date",
       "description": "Date associated with the resource template.",
+      "minLength": 4,
       "example": [
         "2017-05-20"
       ]
@@ -48,6 +51,7 @@
       "type": "string",
       "title": "Description",
       "description": "Textual description associated with the resource template.",
+      "minLength": 3,
       "example": [
         "Metadata for a BIBFRAME Work Abstract entity."
       ]
@@ -56,6 +60,7 @@
       "type": "string",
       "title": "Resource Template Identifier",
       "description": "Identifier associated with a resource template. Eventually, a URI.",
+      "minLength": 3,
       "example": [
         "profile:bf2:AdminMetadata",
         "http://sinopia.io/resources/common/AbstractResourceTemplate"
@@ -67,14 +72,23 @@
     "remark": {
       "type": "string",
       "title": "Remark",
-      "description": "Comment or guiding statement intended to be presented as supplementary information in user display."
+      "description": "Comment or guiding statement intended to be presented as supplementary information in user display.",
+      "minLength": 3,
+      "example": [
+        "http://access.rdatoolkit.org/rdachp2_rda2-7632.html",
+        "used in rare materials profile",
+        "Title information relating to a resource: work title, preferred title, instance title, transcribed title, translated title, variant form of title, etc."
+      ]
     },
     "resourceLabel": {
       "type": "string",
       "title": "Resource Label",
       "description": "Preferred, human readable label associated with the resource template.",
+      "minLength": 3,
       "example": [
-        "BIBFRAME 2.0 Admin Metadata"
+        "BIBFRAME 2.0 Instance",
+        "Primary Contribution",
+        "Place Associated with a Work"
       ]
     },
     "resourceURI": {
@@ -82,20 +96,31 @@
       "format": "uri",
       "title": "Resource URI",
       "description": "URI of the RDF resource type associated with the entity managed by this Resource Template.",
+      "minLength": 5,
       "example": [
-        "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
+        "http://id.loc.gov/ontologies/bibframe/Instance",
+        "http://id.loc.gov/ontologies/bflc/PrimaryContribution",
+        "http://id.loc.gov/ontologies/bibframe/Place"
       ]
     },
     "schema": {
       "const": "https://ld4p.github.io/sinopia/schemas/0.1.0/resource-template.json",
       "title": "URL for Resource Template's JSON schema",
-      "description": "The resource template adheres to the JSON schema at this URL"
+      "description": "The resource template adheres to the JSON schema at this URL",
+      "minLength": 8,
+      "example": [
+        "https://ld4p.github.io/sinopia/schemas/0.1.0/resource-template.json"
+      ]
     },
     "source": {
       "type": "string",
       "format": "uri",
       "title": "Source URI",
-      "description": "URL or URI for the resource template in the owner's source repository or space."
+      "description": "URL or URI for the resource template in the owner's source repository or space.",
+      "minLength": 5,
+      "example": [
+        "https://raw.githubusercontent.com/LD4P/sinopia_sample_profiles/master/resourceTemplates/v0.1.0/monographInstance.json"
+      ]
     }
   }
 }


### PR DESCRIPTION
add a minLength to string properties/attributes to avoid empty strings in actual templates.

This was prompted by https://github.com/LD4P/sinopia_editor/pull/318 and https://github.com/LD4P/sinopia_editor/issues/315, as well as https://github.com/LD4P/sinopia_profile_editor/issues/178

I also added examples, where they were missing.

FYI:  I haven't found any profile level remarks ... perhaps that can go away???