### PR TITLE
schemas v0.1.0 propertyTemplate type resource cannot have defaults

### DIFF
--- a/schemas.md
+++ b/schemas.md
@@ -16,7 +16,6 @@ Property Template:
 - defaults:
     - is dataTypeURI associated with default values only? if so, adjust schema accordingly (put with defaults)
     - is dataTypeURI required when defaults are specified? if so, adjust schema accordingly
-    - can a property with type resource have a default? if not, adjust schema accordingly
 - use resourceTemplates at outer level instead of valueConstraint.valueTemplateRefs (or move  valueTemplateRefs out a level and get rid of resourceTemplates)
 - move useValuesFrom out a level, instead of valueConstraints.useValuesFrom
 - move defaults out a level, instead of valueConstraints.defaults
@@ -52,6 +51,7 @@ Changes from version 0.0.2:
         - (also disallow resourceTemplates)
       - resource:
         - require valueTemplateRefs and disallow useValuesFrom
+        - disallow defaults
       - literal:
         - disallow valueTemplateRefs as well as useValuesFrom
         - (also disallow resourceTemplates)

--- a/schemas/0.1.0/property-template.json
+++ b/schemas/0.1.0/property-template.json
@@ -169,9 +169,9 @@
         }
       },
       "then": {
-        "$comment": "require valueConstraint.valueTemplateRefs",
+        "$comment": "require valueConstraint.valueTemplateRefs and forbid defaults",
         "allOf": [
-          { "$ref": "#/definitions/requires-valueConstraint-valueTemplateRefs" }
+          { "$ref": "#/definitions/requires-valueConstraint-valueTemplateRefs-forbids-defaults" }
         ]
       }
     },
@@ -199,11 +199,14 @@
         }
       }
     },
-    "requires-valueConstraint-valueTemplateRefs": {
+    "requires-valueConstraint-valueTemplateRefs-forbids-defaults": {
       "required": ["valueConstraint"],
       "properties": {
         "valueConstraint" : {
-          "required": ["valueTemplateRefs"]
+          "allOf": [
+            { "required": ["valueTemplateRefs"] },
+            { "not": { "required": [ "defaults" ] } }
+          ]
         }
       }
     },


### PR DESCRIPTION
Per Michelle's request, we want to forbid "resource" type propertyTemplates from having default values.  This is the schema portion of this;  the profile editor issue for the same is https://github.com/LD4P/sinopia_profile_editor/issues/192.

Since this required no changes to v0.1.0 sample profiles, and since we are at v0.x, and since making a new release would require another directory of schemas and of sample profiles, we are sneaking this in to v0.1.0 schemas.    Should a future schema change require changes to the sample profiles, we would increment the schema version. 

Closes #169

Sadly, the ajv validation error message is not all that clear, but addressing opaque validation errors is probably out of scope for this work cycle.

```
[ { keyword: 'not',
    dataPath:
     '.Profile.resourceTemplates[0].propertyTemplates[3].valueConstraint',
    schemaPath:
     '#/definitions/requires-valueConstraint-valueTemplateRefs-forbids-defaults/properties/valueConstraint/allOf/1/not',
    params: {},
    message: 'should NOT be valid',
    schema: { required: [Array] },
    parentSchema: { not: [Object] },
    data: { valueTemplateRefs: [Array], defaults: [Array] } },
  { keyword: 'if',
    dataPath: '.Profile.resourceTemplates[0].propertyTemplates[3]',
    schemaPath: '#/allOf/1/if',
    params: { failingKeyword: 'then' },
    message: 'should match "then" schema',
    schema: { properties: [Object] },
    parentSchema: { if: [Object], then: [Object] },
    data:
     { mandatory: 'false',
       repeatable: 'true',
       type: 'resource',
       resourceTemplates: [],
       valueConstraint: [Object],
       propertyURI: 'http://www.loc.gov/mads/rdf/v1#isIdentifiedByAuthority',
       propertyLabel: 'Other Identifying Attributes (RDA 9.6-9.11)',
       remark: 'http://access.rdatoolkit.org/rdachp9_rda9-5161.html' } } ]
```