### PR TITLE
resource-template: remove unused description attribute

### DIFF
--- a/schemas.md
+++ b/schemas.md
@@ -37,7 +37,6 @@ Changes from version 0.0.2:
 - Resource Template:
     - require author attribute
     - add required date attribute
-    - add required description attribute
     - add required schema attributes
     - add adherence attribute
     - add source attribute

--- a/schemas/0.1.0/resource-template.json
+++ b/schemas/0.1.0/resource-template.json
@@ -47,15 +47,6 @@
         "2017-05-20"
       ]
     },
-    "description": {
-      "type": "string",
-      "title": "Description",
-      "description": "Textual description associated with the resource template.",
-      "minLength": 3,
-      "example": [
-        "Metadata for a BIBFRAME Work Abstract entity."
-      ]
-    },
     "id": {
       "type": "string",
       "title": "Resource Template Identifier",


### PR DESCRIPTION
Per conversation with Michelle, there is no need for resourceTemplates to have a description.  The information is covered by the label and the remark/guiding statement.

Since this schema change required no changes to v0.1.0 sample profiles, and since we are at v0.x, and since making a new release would require another directory of schemas and of sample profiles, we are sneaking this in to v0.1.0 schemas. Should a future schema change require changes to the sample profiles, we would increment the schema version.

