### PR TITLE
schemas v0.0.9 added: more permissive than 0.1.0

### DIFF
--- a/schemas.md
+++ b/schemas.md
@@ -24,7 +24,55 @@ Property Template:
 
 ## Version 0.1.0
 
-Version 0.1.0 JSON Schemas are streamlined for Sinopia work.  
+Version 0.1.0 has more stringent requirements than version 0.0.9, based on how the editor uses the templates.
+It also tries to avoid noise in the templates by forbidding empty attributes.
+
+Changes from version 0.0.9:
+
+- If properties are present, they must not be empty.
+
+- Profile
+    - update schema attribute version
+
+- Resource Template:
+    - require author attribute
+    - require date attribute
+    - update schema attribute version
+
+- Property Template:
+    - conditional JSON schemas that only allow appropriate valueConstraints given the type:
+      - lookup:
+        - disallow valueTemplateRefs
+        - (also disallow resourceTemplates)
+      - resource:
+        - disallow useValuesFrom
+        - disallow defaults
+      - literal:
+        - disallow valueTemplateRefs as well as useValuesFrom
+        - (also disallow resourceTemplates)
+    - type attribute can only be 'literal', 'resource', or 'lookup'
+        - 'resource' and 'lookup' require valueConstraint
+
+    - valueConstraint can have at most one of useValuesFrom, valueTemplateRefs
+    - valueConstaint.useValuesFrom requires at least one entry (or it shouldn't be present)
+    - valueConstaint.valueTemplateRefs requires at least one entry (or it shouldn't be present)
+    - valueConstraint.valueDataType requires dataTypeURI (or it shouldn't be present)
+
+The schemas are:
+
+- <https://ld4p.github.io/sinopia/schemas/0.1.0/profile.json>
+- <https://ld4p.github.io/sinopia/schemas/0.1.0/resource-templates-array.json>
+- <https://ld4p.github.io/sinopia/schemas/0.1.0/resource-template.json>
+- <https://ld4p.github.io/sinopia/schemas/0.1.0/property-templates-array.json>
+- <https://ld4p.github.io/sinopia/schemas/0.1.0/property-template.json>
+
+special bonus schema
+- <https://ld4p.github.io/sinopia/schemas/0.1.0/profiles-array.json>
+
+
+## Version 0.0.9
+
+Version 0.0.9 JSON Schemas are streamlined for Sinopia work.
 
 Changes from version 0.0.2:
 
@@ -35,30 +83,20 @@ Changes from version 0.0.2:
     - add source attribute
 
 - Resource Template:
-    - require author attribute
-    - add required date attribute
     - add required schema attributes
     - add adherence attribute
+    - add author attribute
+    - add date attribute
     - add source attribute
 
 - Property Template:
     - type attribute can only be 'literal', 'resource', or 'lookup'
-      - 'resource' and 'lookup' require valueConstraint
-    - conditional JSON schemas that only allow appropriate valueConstraints given the type:
+    - conditional JSON schemas that require appropriate valueConstraints given the type:
       - lookup:
-        - require useValuesFrom and disallow valueTemplateRefs
-        - (also disallow resourceTemplates)
+        - require valueConstraints.useValuesFrom
       - resource:
-        - require valueTemplateRefs and disallow useValuesFrom
-        - disallow defaults
-      - literal:
-        - disallow valueTemplateRefs as well as useValuesFrom
-        - (also disallow resourceTemplates)
+        - require valueConstraints.valueTemplateRefs
     - mandatory and repeatable properties can be proper booleans OR strings (e.g. true or 'true')
-    - valueConstraint can have at most one of useValuesFrom, valueTemplateRefs
-    - valueConstaint.useValuesFrom requires at least one entry (or it shouldn't be present)
-    - valueConstaint.valueTemplateRefs requires at least one entry (or it shouldn't be present)
-    - valueConstraint.valueDataType requires dataTypeURI (or it shouldn't be present)
     - valueConstraint.editable attribute removed as it will always be true
     - removed attributes that were never used or ignored in profile editor, BFE and RDF generated:
       - valueConstraint.remark
@@ -71,14 +109,14 @@ Changes from version 0.0.2:
 
 The schemas are:
 
-- <https://ld4p.github.io/sinopia/schemas/0.1.0/profile.json>
-- <https://ld4p.github.io/sinopia/schemas/0.1.0/resource-templates-array.json>
-- <https://ld4p.github.io/sinopia/schemas/0.1.0/resource-template.json>
-- <https://ld4p.github.io/sinopia/schemas/0.1.0/property-templates-array.json>
-- <https://ld4p.github.io/sinopia/schemas/0.1.0/property-template.json>
+- <https://ld4p.github.io/sinopia/schemas/0.0.9/profile.json>
+- <https://ld4p.github.io/sinopia/schemas/0.0.9/resource-templates-array.json>
+- <https://ld4p.github.io/sinopia/schemas/0.0.9/resource-template.json>
+- <https://ld4p.github.io/sinopia/schemas/0.0.9/property-templates-array.json>
+- <https://ld4p.github.io/sinopia/schemas/0.0.9/property-template.json>
 
 special bonus schema
-- <https://ld4p.github.io/sinopia/schemas/0.1.0/profiles-array.json>
+- <https://ld4p.github.io/sinopia/schemas/0.0.9/profiles-array.json>
 
 
 ## Version 0.0.2

--- a/schemas/0.0.9/profile.json
+++ b/schemas/0.0.9/profile.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://ld4p.github.io/sinopia/schemas/0.0.9/profile.json",
+  "type": "object",
+  "title": "Sinopia Profile Schema",
+  "description": "Profile, or array of Resource Templates with some top-level metadata.",
+  "version": "0.0.9",
+  "required": [ "Profile" ],
+  "additionalProperties": false,
+  "properties": {
+    "Profile": {
+      "type": "object",
+      "title": "Profile" ,
+      "description": "Profile key always at top level of a Sinopia Profile.",
+      "required": [
+        "author",
+        "date",
+        "description",
+        "id",
+        "resourceTemplates",
+        "schema",
+        "title"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "adherence": {
+          "type": "string",
+          "title": "Adherence",
+          "description": "The standards or rules that this profile adheres to.",
+          "example": [
+            "PCC",
+            "PCC RDA Working Group"
+          ]
+        },
+        "author": {
+          "type": "string",
+          "title": "Author",
+          "description": "Contact information associated with the profile.",
+          "minLength": 2,
+          "example": [
+            "PCC",
+            "Michelle Futornick",
+            "Cornell University Cataloging Department"
+          ]
+        },
+        "date": {
+          "type": "string",
+          "format": "date",
+          "title": "Date",
+          "description": "Date associated with the profile",
+          "minLength": 4,
+          "example": [
+            "2017-05-20"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Textual description associated with the profile.",
+          "minLength": 3,
+          "example": [
+            "Metadata for BIBFRAME Resources"
+          ]
+        },
+        "id": {
+          "type": "string",
+          "title": "Identifier",
+          "description": "Unique identifier associated with the profile. Eventually, a Profile URI.",
+          "minLength": 3,
+          "example": [
+            "profile:bf2:AdminMetadata",
+            "http://sinopia.io/resources/common/AdminMetadataProfile"
+          ]
+        },
+        "remark": {
+          "type": "string",
+          "title": "Remark",
+          "description": "Comment or guiding statement intended to be presented as supplementary information in user display.",
+          "example": [
+            "Title information relating to a resource: work title, preferred title, instance title, transcribed title, translated title, variant form of title, etc."
+          ]
+        },
+        "resourceTemplates": {
+          "$ref": "https://ld4p.github.io/sinopia/schemas/0.0.9/resource-templates-array.json"
+        },
+        "schema": {
+          "const": "https://ld4p.github.io/sinopia/schemas/0.0.9/profile.json",
+          "title": "URL for Profile's JSON schema",
+          "description": "The profile adheres to the JSON schema at this URL",
+          "minLength": 8,
+          "example": [
+            "https://ld4p.github.io/sinopia/schemas/0.0.9/profile.json"
+          ]
+        },
+        "source": {
+          "type": "string",
+          "format": "uri",
+          "title": "Source URI",
+          "description": "URL or URI for the profile in the author's source repository or space.",
+          "example": [
+            "https://raw.githubusercontent.com/LD4P/sinopia_sample_profiles/master/profiles/v0.0.9/BIBFRAME%202.0%20Agents.json"
+          ]
+        },
+        "title": {
+          "type": "string",
+          "title": "Title",
+          "description": "Textual title associated with the profile.",
+          "minLength": 3,
+          "example": [
+            "BIBFRAME 2.0 Agents"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/schemas/0.0.9/profiles-array.json
+++ b/schemas/0.0.9/profiles-array.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://ld4p.github.io/sinopia/schemas/0.0.9/profiles-array.json",
+  "title": "Profile Array Schema (i.e. Multiple Profiles) (by Sinopia)",
+  "version": "0.0.9",
+  "type": "array",
+  "items": {
+    "$ref": "https://ld4p.github.io/sinopia/schemas/0.0.9/profile.json"
+  }
+}

--- a/schemas/0.0.9/property-template.json
+++ b/schemas/0.0.9/property-template.json
@@ -1,0 +1,222 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://ld4p.github.io/sinopia/schemas/0.0.9/property-template.json",
+  "title": "Sinopia Property Template Schema",
+  "description": "Property template for property associated with the entity described by a resource template.",
+  "version": "0.0.9",
+  "type": "object",
+  "required": [
+    "propertyURI",
+    "propertyLabel",
+    "type"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "mandatory": {
+      "type": ["boolean", "string"],
+      "enum": ["true", "false"],
+      "title": "Mandatory",
+      "description": "Indication that a value for the property is required. If unspecified, defaults to false.",
+      "default": false
+    },
+    "propertyLabel": {
+      "type": "string",
+      "title": "Property Label",
+      "description": "Preferred, human readable label associated with the property.",
+      "minLength": 3,
+      "example": [
+        "Search LCNAF/LCSH",
+        "Place of Origin of the Work (RDA 6.5)",
+        "Contents (LC-PCC PS 25.1)",
+        "Related Manifestation",
+        "Has Item"
+      ]
+    },
+    "propertyURI": {
+      "type": "string",
+      "format": "uri",
+      "title": "Property URI",
+      "description": "URI of the RDF property to be used.",
+      "minLength": 8,
+      "example": [
+        "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
+      ]
+    },
+    "remark": {
+      "type": "string",
+      "title": "Remark",
+      "description": "Comment or guiding statement intended to be presented as supplementary information in user display.",
+      "example": [
+        "http://access.rdatoolkit.org/6.17.html",
+        "http://www.loc.gov/mads/rdf/v1#",
+        "https://www.loc.gov/standards/mods/userguide/recordinfo.html#recordidentifier"
+      ]
+    },
+    "repeatable": {
+      "type": ["boolean","string"],
+      "enum": ["true", "false"],
+      "title": "Repeatable",
+      "description": "Indication that the property is repeatable. If unspecified, defaults to true.",
+      "default": true
+    },
+    "resourceTemplates": {
+      "type": "array",
+      "title": "Always empty array of Resource Template References",
+      "description": "This is not currently used, but should/could replace valueConstraint.valueTemplateRefs",
+      "maxItems": 0
+    },
+    "type": {
+      "type": "string",
+      "enum": ["literal", "lookup", "resource"],
+      "title": "Type",
+      "description": "Type of value (literal / resource / lookup) that is allowed by this property."
+    },
+    "valueConstraint": {
+      "type": "object",
+      "title": "Value Constraint",
+      "description": "Constraint associated with the value.",
+      "additionalProperties": false,
+      "properties": {
+        "valueTemplateRefs": {
+          "type": "array",
+          "title": "Array of Resource Template References (for property type resource)",
+          "description": "Array of identifiers (eventually URIs) of Resource Templates used by property type resource.",
+          "items": {
+            "type": "string"
+          },
+          "example": [
+            "['sinopia:resourceTemplate:bf2:Agent:Person', 'sinopia:resourceTemplate:bf2:Identifiers:Barcode', 'sinopia:resourceTemplate:bflc:Agents:PrimaryContribution']"
+          ]
+        },
+        "useValuesFrom": {
+          "type": "array",
+          "title": "Use Values From (these URIs for property type lookup)",
+          "description": "Array of Authority URIs or Vocabulary Lookup API identifiers to perform a lookup against (used by property type lookup)",
+          "items": {
+            "type": "string"
+          },
+          "example": [
+            "['http://id.loc.gov/authorities/names', 'http://mlvlp04.loc.gov:8230/resources/works', 'http://id.loc.gov/authorities/genreForms']"
+          ]
+        },
+        "valueDataType": {
+          "type": "object",
+          "title": "Value Data Types",
+          "description": "Data Type information: Type URI.",
+          "additionalProperties": false,
+          "properties": {
+            "dataTypeURI": {
+              "type": "string",
+              "format": "uri",
+              "title": "Data Type URI",
+              "description": "URI for the Data Type of the Lookup Value default.",
+              "example": [
+                "http://id.loc.gov/ontologies/bibframe/Work",
+                "http://id.loc.gov/ontologies/bflc/PrimaryContribution",
+                "http://www.loc.gov/mads/rdf/v1#Affiliation"
+              ]
+            }
+          }
+        },
+        "defaults": {
+          "type": "array",
+          "title": "array of default values",
+          "description": "array of default values each comprised of default literal and URI",
+          "items": {
+            "type": "object",
+            "title": "default Literal + URI",
+            "description": "a default value is specified with a literal and a URI",
+            "required": ["defaultURI", "defaultLiteral"],
+            "additionalProperties": false,
+            "properties": {
+              "defaultURI": {
+                "type": "string",
+                "format": "uri",
+                "title": "Default URI",
+                "description": "default value URI",
+                "examples": [
+                  "http://id.loc.gov/vocabulary/contentTypes/prm",
+                  "http://id.loc.gov/vocabulary/subjectSchemes/lcsh"
+                ]
+              },
+              "defaultLiteral": {
+                "type": "string",
+                "title": "Default Literal",
+                "description": "default literal value",
+                "examples": [
+                  "performed music",
+                  "LCSH"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "type": { "const": "lookup" }
+        }
+      },
+      "then": {
+        "$comment": "require valueConstraint.useValuesFrom",
+        "$ref": "#/definitions/requires-valueConstraint-useValuesFrom"
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": { "const": "resource" }
+        }
+      },
+      "then": {
+        "$comment": "require valueConstraint.valueTemplateRefs and forbid defaults",
+        "allOf": [
+          { "$ref": "#/definitions/requires-valueConstraint-valueTemplateRefs" }
+        ]
+      }
+    }
+  ],
+  "definitions": {
+    "requires-valueConstraint-useValuesFrom": {
+      "required": ["valueConstraint"],
+      "properties": {
+        "valueConstraint" : {
+          "required": ["useValuesFrom"]
+        }
+      }
+    },
+    "requires-valueConstraint-valueTemplateRefs": {
+      "required": ["valueConstraint"],
+      "properties": {
+        "valueConstraint" : {
+          "required": ["valueTemplateRefs"]
+        }
+      }
+    },
+    "requires-valueConstraint-valueTemplateRefs-forbids-defaults": {
+      "required": ["valueConstraint"],
+      "properties": {
+        "valueConstraint" : {
+          "allOf": [
+            { "required": ["valueTemplateRefs"] },
+            { "not": { "required": [ "defaults" ] } }
+          ]
+        }
+      }
+    },
+    "valueConstraint-requires-neither-templateRefs-nor-valuesFrom": {
+      "properties": {
+        "valueConstraint" : {
+          "allOf": [
+            { "not": { "required": [ "useValuesFrom" ] } },
+            { "not": { "required": [ "valueTemplateRefs" ] } }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/schemas/0.0.9/property-templates-array.json
+++ b/schemas/0.0.9/property-templates-array.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://ld4p.github.io/sinopia/schemas/0.0.9/property-templates-array.json",
+  "title": "Sinopia Property Template Array Schema (i.e. Multiple Property Templates)",
+  "version": "0.0.9",
+  "type": "array",
+  "items": {
+    "$ref": "https://ld4p.github.io/sinopia/schemas/0.0.9/property-template.json"
+  },
+  "minItems": 1
+}

--- a/schemas/0.0.9/resource-template.json
+++ b/schemas/0.0.9/resource-template.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://ld4p.github.io/sinopia/schemas/0.0.9/resource-template.json",
+  "type": "object",
+  "title": "Sinopia Resource Template Schema",
+  "version": "0.0.9",
+  "description": "A Resource Template construct (or hash) describes one of the various Sinopia entities (Works, Instances, Agent, etc.) associated with a given entity type and set of properties asserted against the entity.",
+  "required": [
+    "id",
+    "propertyTemplates",
+    "resourceLabel",
+    "resourceURI",
+    "schema"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "adherence": {
+      "type": "string",
+      "title": "Adherence",
+      "description": "The standards or rules that this resource template adheres to.",
+      "example": [
+        "PCC",
+        "PCC RDA Working Group"
+      ]
+    },
+    "author": {
+      "type": "string",
+      "title": "Author",
+      "description": "Contact information associated with the resource template.",
+      "minLength": 2,
+      "example": [
+        "PCC",
+        "Michelle Futornick",
+        "Cornell University Cataloging Department"
+      ]
+    },
+    "date": {
+      "type": "string",
+      "format": "date",
+      "title": "Date",
+      "description": "Date associated with the resource template.",
+      "minLength": 4,
+      "example": [
+        "2017-05-20"
+      ]
+    },
+    "id": {
+      "type": "string",
+      "title": "Resource Template Identifier",
+      "description": "Identifier associated with a resource template. Eventually, a URI.",
+      "minLength": 3,
+      "example": [
+        "profile:bf2:AdminMetadata",
+        "http://sinopia.io/resources/common/AbstractResourceTemplate"
+      ]
+    },
+    "propertyTemplates": {
+      "$ref": "https://ld4p.github.io/sinopia/schemas/0.0.9/property-templates-array.json"
+    },
+    "remark": {
+      "type": "string",
+      "title": "Remark",
+      "description": "Comment or guiding statement intended to be presented as supplementary information in user display.",
+      "example": [
+        "http://access.rdatoolkit.org/rdachp2_rda2-7632.html",
+        "used in rare materials profile",
+        "Title information relating to a resource: work title, preferred title, instance title, transcribed title, translated title, variant form of title, etc."
+      ]
+    },
+    "resourceLabel": {
+      "type": "string",
+      "title": "Resource Label",
+      "description": "Preferred, human readable label associated with the resource template.",
+      "minLength": 3,
+      "example": [
+        "BIBFRAME 2.0 Instance",
+        "Primary Contribution",
+        "Place Associated with a Work"
+      ]
+    },
+    "resourceURI": {
+      "type": "string",
+      "format": "uri",
+      "title": "Resource URI",
+      "description": "URI of the RDF resource type associated with the entity managed by this Resource Template.",
+      "minLength": 5,
+      "example": [
+        "http://id.loc.gov/ontologies/bibframe/Instance",
+        "http://id.loc.gov/ontologies/bflc/PrimaryContribution",
+        "http://id.loc.gov/ontologies/bibframe/Place"
+      ]
+    },
+    "schema": {
+      "const": "https://ld4p.github.io/sinopia/schemas/0.0.9/resource-template.json",
+      "title": "URL for Resource Template's JSON schema",
+      "description": "The resource template adheres to the JSON schema at this URL",
+      "minLength": 8,
+      "example": [
+        "https://ld4p.github.io/sinopia/schemas/0.0.9/resource-template.json"
+      ]
+    },
+    "source": {
+      "type": "string",
+      "format": "uri",
+      "title": "Source URI",
+      "description": "URL or URI for the resource template in the owner's source repository or space.",
+      "example": [
+        "https://raw.githubusercontent.com/LD4P/sinopia_sample_profiles/master/resourceTemplates/v0.1.0/monographInstance.json"
+      ]
+    }
+  }
+}

--- a/schemas/0.0.9/resource-templates-array.json
+++ b/schemas/0.0.9/resource-templates-array.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://ld4p.github.io/sinopia/schemas/0.0.9/resource-templates-array.json",
+  "title": "Resource Template Array Schema (i.e. Multiple Resource Templates) (by Sinopia)",
+  "version": "0.0.9",
+  "type": "array",
+  "items": {
+    "$ref": "https://ld4p.github.io/sinopia/schemas/0.0.9/resource-template.json"
+  },
+  "minItems": 1
+}


### PR DESCRIPTION
These schemas will validate profiles created by the profile editor, EXCEPT:

while resourceLabel and propertyLabel are indicated as required with an asterisk, this is not enforced -- you can export a profile without filling them in.  

Similary, resourceTemplate author is marked as required in the PE UI, but I relaxed the schemas so resourceTemplate author is not required.  Given that we're using profiles, not resourceTemplates, and given that we're not requiring, displaying or producing "date" for resourceTemplates ... (shrug).

![image](https://user-images.githubusercontent.com/96775/52883407-a6946100-311f-11e9-83b1-9d6df09afd3b.png)


Happy to do either of
- leave as is
- ensure Labels and rt author are non-empty before save

I believe the catalogers really will want labels on their resource and property templates, so I'm inclined to keep them required in the schemas.

Closes #176