### PR TITLE
Validate that resource template id contains no spaces

### DIFF
--- a/schemas/0.0.9/resource-template.json
+++ b/schemas/0.0.9/resource-template.json
@@ -49,6 +49,7 @@
       "title": "Resource Template Identifier",
       "description": "Identifier associated with a resource template. Eventually, a URI.",
       "minLength": 3,
+      "pattern": "^\\S+$",
       "example": [
         "profile:bf2:AdminMetadata",
         "http://sinopia.io/resources/common/AbstractResourceTemplate"

--- a/schemas/0.1.0/resource-template.json
+++ b/schemas/0.1.0/resource-template.json
@@ -52,6 +52,7 @@
       "title": "Resource Template Identifier",
       "description": "Identifier associated with a resource template. Eventually, a URI.",
       "minLength": 3,
+      "pattern": "^\\S+$",
       "example": [
         "profile:bf2:AdminMetadata",
         "http://sinopia.io/resources/common/AbstractResourceTemplate"


### PR DESCRIPTION
Cannot post a resource template to trellis if the id has spaces in it. For example:

`"id": "HRC:RT:ARM Monograph:binding:designer"`
should be
`"id": "HRC:RT:ARM:Monograph:binding:designer"`
note the colon after `ARM`

ID field is not just a text field where they can put whatever they want. When the RT is posted to trellis the ID becomes the slug and hence the path in the resource URI, so it cannot have any spaces.

http://trellis.foo/repository/ld4p/HRC:RT:ARM:Monograph:binding:designer 
is a good URI, but: 
http://trellis.foo/repository/ld4p/HRC:RT:ARM Monograph:binding:designer 
is not.
