### PR TITLE
schemas 0.0.9 propertyTemplate: relax restrictions on defaults object

### DIFF
--- a/schemas.md
+++ b/schemas.md
@@ -72,7 +72,14 @@ special bonus schema
 
 ## Version 0.0.9
 
-Version 0.0.9 JSON Schemas are streamlined for Sinopia work.
+Tweak made 2019-05-14:  (
+- This was a small, well tested, backwards compatible tweak and we chose NOT to create a new version of the JSON schemas for more seamless backwards compatibility (and against string semantic versioning).
+- Property Template:
+    - valueConstraint.defaults
+      - `defaultURI` is now an ordinary string; URI format is not required.  This allows for `defaultURI` to be an empty string.
+      - `defaults` array's objects have no required fields.  This allows for either or both of `defaultURI` and `defaultLiteral` to be present or missing.
+
+Version 0.0.9 JSON Schemas are streamlined for Sinopia work.      
 
 Changes from version 0.0.2:
 

--- a/schemas/0.0.9/property-template.json
+++ b/schemas/0.0.9/property-template.json
@@ -126,12 +126,10 @@
             "type": "object",
             "title": "default Literal + URI",
             "description": "a default value is specified with a literal and a URI",
-            "required": ["defaultURI", "defaultLiteral"],
             "additionalProperties": false,
             "properties": {
               "defaultURI": {
                 "type": "string",
-                "format": "uri",
                 "title": "Default URI",
                 "description": "default value URI",
                 "examples": [


### PR DESCRIPTION
This addresses LD4P/sinopia_editor#389: JSON schema for a PropertyTemplate should not require a `defaultURI`.

These formerly invalid propertyTemplates are now valid:
```
{
  "type": "literal",
  "valueConstraint": {
    "defaults": [
      {
        "defaultURI": "",
        "defaultLiteral": "mydefaultvalue"
      }
    ]
  },
  "propertyURI": "http://example.org/testDefaults",
  "propertyLabel": "empty defaultURI"
}
```

```json
{
  "type": "literal",
  "valueConstraint": {
    "defaults": [
      {
        "defaultURI": "http://example.org/defaultURI",
        "defaultLiteral": ""
      }
    ]
  },
  "propertyURI": "http://example.org/testDefaults",
  "propertyLabel": "empty string defaultLiteral"
}
```

```json
{
  "type": "literal",
  "valueConstraint": {
    "defaults": [
      {
        "defaultURI": "http://example.org/defaultURI"
      }
    ]
  },
  "propertyURI": "http://example.org/testDefaults",
  "propertyLabel": "no defaultLiteral"
}
```

```json
{
  "type": "literal",
  "valueConstraint": {
    "defaults": [
      {
        "defaultLiteral": "mydefaultvalue"
      }
    ]
  },
  "propertyURI": "http://example.org/testDefaults",
  "propertyLabel": "no defaultURI"
}
```