### PR TITLE
Internal refs in the schemas were not pointing to the correct version

### DIFF
--- a/schemas/0.2.1/profile.json
+++ b/schemas/0.2.1/profile.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://ld4p.github.io/sinopia/schemas/0.2.0/profile.json",
+  "$id": "https://ld4p.github.io/sinopia/schemas/0.2.1/profile.json",
   "type": "object",
   "title": "Sinopia Profile Schema",
   "description": "Profile, or array of Resource Templates with some top-level metadata.",
@@ -83,15 +83,15 @@
           ]
         },
         "resourceTemplates": {
-          "$ref": "https://ld4p.github.io/sinopia/schemas/0.2.0/resource-templates-array.json"
+          "$ref": "https://ld4p.github.io/sinopia/schemas/0.2.1/resource-templates-array.json"
         },
         "schema": {
-          "const": "https://ld4p.github.io/sinopia/schemas/0.2.0/profile.json",
+          "const": "https://ld4p.github.io/sinopia/schemas/0.2.1/profile.json",
           "title": "URL for Profile's JSON schema",
           "description": "The profile adheres to the JSON schema at this URL",
           "minLength": 8,
           "example": [
-            "https://ld4p.github.io/sinopia/schemas/0.2.0/profile.json"
+            "https://ld4p.github.io/sinopia/schemas/0.2.1/profile.json"
           ]
         },
         "source": {

--- a/schemas/0.2.1/profiles-array.json
+++ b/schemas/0.2.1/profiles-array.json
@@ -1,10 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://ld4p.github.io/sinopia/schemas/0.2.0/profiles-array.json",
+  "$id": "https://ld4p.github.io/sinopia/schemas/0.2.1/profiles-array.json",
   "title": "Profile Array Schema (i.e. Multiple Profiles) (by Sinopia)",
   "version": "0.2.1",
   "type": "array",
   "items": {
-    "$ref": "https://ld4p.github.io/sinopia/schemas/0.2.0/profile.json"
+    "$ref": "https://ld4p.github.io/sinopia/schemas/0.2.1/profile.json"
   }
 }

--- a/schemas/0.2.1/property-template.json
+++ b/schemas/0.2.1/property-template.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://ld4p.github.io/sinopia/schemas/0.2.0/property-template.json",
+  "$id": "https://ld4p.github.io/sinopia/schemas/0.2.1/property-template.json",
   "title": "Sinopia Property Template Schema",
   "description": "Property template for property associated with the entity described by a resource template.",
   "version": "0.2.1",

--- a/schemas/0.2.1/property-templates-array.json
+++ b/schemas/0.2.1/property-templates-array.json
@@ -1,11 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://ld4p.github.io/sinopia/schemas/0.2.0/property-templates-array.json",
+  "$id": "https://ld4p.github.io/sinopia/schemas/0.2.1/property-templates-array.json",
   "title": "Sinopia Property Template Array Schema (i.e. Multiple Property Templates)",
   "version": "0.2.1",
   "type": "array",
   "items": {
-    "$ref": "https://ld4p.github.io/sinopia/schemas/0.2.0/property-template.json"
+    "$ref": "https://ld4p.github.io/sinopia/schemas/0.2.1/property-template.json"
   },
   "minItems": 1
 }

--- a/schemas/0.2.1/resource-template.json
+++ b/schemas/0.2.1/resource-template.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://ld4p.github.io/sinopia/schemas/0.2.0/resource-template.json",
+  "$id": "https://ld4p.github.io/sinopia/schemas/0.2.1/resource-template.json",
   "type": "object",
   "title": "Sinopia Resource Template Schema",
   "version": "0.2.1",
@@ -59,7 +59,7 @@
       ]
     },
     "propertyTemplates": {
-      "$ref": "https://ld4p.github.io/sinopia/schemas/0.2.0/property-templates-array.json"
+      "$ref": "https://ld4p.github.io/sinopia/schemas/0.2.1/property-templates-array.json"
     },
     "remark": {
       "type": "string",
@@ -96,12 +96,12 @@
       ]
     },
     "schema": {
-      "const": "https://ld4p.github.io/sinopia/schemas/0.2.0/resource-template.json",
+      "const": "https://ld4p.github.io/sinopia/schemas/0.2.1/resource-template.json",
       "title": "URL for Resource Template's JSON schema",
       "description": "The resource template adheres to the JSON schema at this URL",
       "minLength": 8,
       "example": [
-        "https://ld4p.github.io/sinopia/schemas/0.2.0/resource-template.json"
+        "https://ld4p.github.io/sinopia/schemas/0.2.1/resource-template.json"
       ]
     },
     "source": {

--- a/schemas/0.2.1/resource-templates-array.json
+++ b/schemas/0.2.1/resource-templates-array.json
@@ -1,11 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://ld4p.github.io/sinopia/schemas/0.2.0/resource-templates-array.json",
+  "$id": "https://ld4p.github.io/sinopia/schemas/0.2.1/resource-templates-array.json",
   "title": "Resource Template Array Schema (i.e. Multiple Resource Templates) (by Sinopia)",
   "version": "0.2.1",
   "type": "array",
   "items": {
-    "$ref": "https://ld4p.github.io/sinopia/schemas/0.2.0/resource-template.json"
+    "$ref": "https://ld4p.github.io/sinopia/schemas/0.2.1/resource-template.json"
   },
   "minItems": 1
 }


### PR DESCRIPTION
In PR #240, neglected to update all of the internal refs to version `0.2.1`, this PR fixes that error.