### PR TITLE
Manually merging Schema changes into 0.2.1 version

### DIFF
--- a/schemas.md
+++ b/schemas.md
@@ -22,6 +22,9 @@ Property Template:
 - move dataTypeURI out two levels, instead of valueConstraints.valueDataType.dataTypeURI or maybe include it within default, if it is only used for (type lookup with a ?) default.
 - only accept boolean (not string) for true/false.  (e.g. true not "true")
 
+## Version 0.2.1
+Adds support for subtype equals `context`. 
+
 ## Version 0.2.0
 
 Version 0.2.0 is the same as version 0.1.0 in all respects except that it further requires that a resource template ID contain no spaces in the ID string. This is due to the fact that the resource template ID becomes the last path part of the Sinopia server resource URI, and that URI cannot contain spaces in order to resolve correctly when fetching the resource.

--- a/schemas/0.2.1/property-template.json
+++ b/schemas/0.2.1/property-template.json
@@ -74,7 +74,7 @@
     },
     "type": {
       "type": "string",
-      "enum": ["literal", "lookup", "resource"],
+      "enum": ["literal", "literal-lang", "target", "list", "lookup", "resource"],
       "title": "Type",
       "description": "Type of value (literal / resource / lookup) that is allowed by this property."
     },
@@ -137,7 +137,10 @@
             "type": "object",
             "title": "default Literal + URI",
             "description": "a default value is specified with a literal and a URI",
-            "required": ["defaultURI", "defaultLiteral"],
+            "anyOf": [
+              { "required": ["defaultURI"] },
+              { "required": [ "defaultLiteral"] }
+            ],
             "additionalProperties": false,
             "properties": {
               "defaultURI": {


### PR DESCRIPTION
Merging PR [229](https://github.com/LD4P/sinopia/pull/229) was for branch `0.2.0`, need to updated version `0.2.1` property-template validation for LOC and also fixes an issue raised in the LD4P Slack channel regarding `defaults` in templates. 